### PR TITLE
Ticket #8225, leaving notifying master as only master for current loop

### DIFF
--- a/pdns/slavecommunicator.cc
+++ b/pdns/slavecommunicator.cc
@@ -514,7 +514,7 @@ void CommunicatorClass::addSlaveCheckRequest(const DomainInfo& di, const ComboAd
   // query goes to that one.
   for (vector<string>::iterator it = ours.masters.begin(); it != ours.masters.end(); ++it) {
     if (*it == remote_address) {
-	ours.masters.erase(it);
+	ours.masters.clear();
         ours.masters.push_back(remote_address);
         break;
     } 


### PR DESCRIPTION
There is a need to clear the masters list to make sure it'll always target the notifying master and not any other master
